### PR TITLE
Remove unused paint and fix tests

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,14 +3,15 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:file_picker/file_picker.dart';
 
-void main() => runApp(WotMapEditor());
+void main() => runApp(const WotMapEditor());
 
 class WotMapEditor extends StatelessWidget {
+  const WotMapEditor({super.key});
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'WoT Map Editor',
-      home: MapEditorPage(),
+      home: const MapEditorPage(),
     );
   }
 }
@@ -19,6 +20,7 @@ enum ToolType { point, zone, brush }
 enum TankType { none, lt, mt, ht, td, spg, route }
 
 class MapEditorPage extends StatefulWidget {
+  const MapEditorPage({super.key});
   @override
   _MapEditorPageState createState() => _MapEditorPageState();
 }
@@ -333,8 +335,6 @@ class OverlayPainter extends CustomPainter {
       ..color = Colors.red.withOpacity(0.3)
       ..style = PaintingStyle.fill;
 
-    final pointPaint = Paint()
-      ..style = PaintingStyle.fill;
 
     // Assign color by tank type if available
     Map<String, Color> tankColors = {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,7 +30,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  file_picker: ^10.1.9 # <--- Убедитесь, что отступ здесь правильный
+  file_picker: ^10.1.9
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,10 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:wotpositonmarker/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
-
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+  testWidgets('shows start message', (WidgetTester tester) async {
+    await tester.pumpWidget(const WotMapEditor());
+    expect(find.text('Select an image to start'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- make constructors constant for top-level widgets
- remove unused `pointPaint` variable from `OverlayPainter`
- clean up `pubspec.yaml`
- rewrite the example widget test

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ffddcd1108333a86d239270aa56ea